### PR TITLE
Support for googleAnalytics

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -14,4 +14,8 @@
     {{ range .AlternativeOutputFormats -}}
         {{ printf `<link rel="%s" type="%s" href="%s" title="%s" />` .Rel .MediaType.Type .Permalink $.Site.Title | safeHTML }}
     {{ end -}}
+        
+    {{ if hugo.Environment | eq "production" }}
+        {{ template "_internal/google_analytics_async.html" . }}
+    {{ end }}
 </head>


### PR DESCRIPTION
Currently, the theme does not support googleAnalytics, I reckon. So adding these lines do the job, right?
The coded added is from the template given by Hugo [https://gohugo.io/templates/internal/#use-the-google-analytics-template].