### PR TITLE
Fix RSS social link

### DIFF
--- a/data/notrack/social.yaml
+++ b/data/notrack/social.yaml
@@ -506,6 +506,5 @@ rss:
   weight: 64
   url: /index.xml
   title: RSS
-  newtab: true
   icon:
     class: fas fa-rss fa-fw

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -22,7 +22,7 @@ paginate = 4
     linkedin = "example"
     email = "example@example.com"
     mastodon = "example"
-    medium = "example"
+    rss = "rss won't use the value you give it so you can put anything here"
     keybase = "example"
 
 [taxonomies]

--- a/layouts/shortcodes/contact-box.html
+++ b/layouts/shortcodes/contact-box.html
@@ -17,6 +17,8 @@
         <li><a href="{{- .prefix -}}{{ .user }}"><i class="{{- .icon.class -}}"></i>{{ .title }}</a></li>
         {{- else if .template -}}
         <li><a href="{{- printf .template .user -}}"><i class="{{- .icon.class -}}"></i>{{ .title }}</a></li>
+        {{- else if .url -}}
+        <li><a href="{{- .url -}}"><i class="{{- .icon.class -}}"></i>{{ .title }}</a></li>
         {{- end -}}
     {{- end -}}
     </ul>

--- a/layouts/shortcodes/social.html
+++ b/layouts/shortcodes/social.html
@@ -17,6 +17,8 @@
                 <li><a href="{{- .prefix -}}{{ .user }}"><i class="{{- .icon.class -}}"></i>{{ .title }}</a></li>
                 {{- else if .template -}}
                 <li><a href="{{- printf .template .user -}}"><i class="{{- .icon.class -}}"></i>{{ .title }}</a></li>
+                {{- else if .url -}}
+                <li><a href="{{- .url -}}"><i class="{{- .icon.class -}}"></i>{{ .title }}</a></li>
                 {{- end -}}
             {{- end -}}
         </ul>


### PR DESCRIPTION
There was a bug where the RSS social link wouldn't show up in the social and contact-box shortcodes even when configured to be there. This commit fixes that and closes #10
