### PR TITLE
Add rel="me" to all social links

### DIFF
--- a/layouts/shortcodes/contact-box.html
+++ b/layouts/shortcodes/contact-box.html
@@ -14,9 +14,9 @@
 
     {{ range sort $socialArray "weight" -}}
         {{- if .prefix -}}
-        <li><a href="{{- .prefix -}}{{ .user }}"><i class="{{- .icon.class -}}"></i>{{ .title }}</a></li>
+        <li><a href="{{- .prefix -}}{{ .user }}" rel="me"><i class="{{- .icon.class -}}"></i>{{ .title }}</a></li>
         {{- else if .template -}}
-        <li><a href="{{- printf .template .user -}}"><i class="{{- .icon.class -}}"></i>{{ .title }}</a></li>
+        <li><a href="{{- printf .template .user -}}" rel="me"><i class="{{- .icon.class -}}"></i>{{ .title }}</a></li>
         {{- else if .url -}}
         <li><a href="{{- .url -}}"><i class="{{- .icon.class -}}"></i>{{ .title }}</a></li>
         {{- end -}}

--- a/layouts/shortcodes/social.html
+++ b/layouts/shortcodes/social.html
@@ -14,9 +14,9 @@
             {{ end }}
             {{ range sort $socialArray "weight" -}}
                 {{- if .prefix -}}
-                <li><a href="{{- .prefix -}}{{ .user }}"><i class="{{- .icon.class -}}"></i>{{ .title }}</a></li>
+                <li><a href="{{- .prefix -}}{{ .user }}" rel="me"><i class="{{- .icon.class -}}"></i>{{ .title }}</a></li>
                 {{- else if .template -}}
-                <li><a href="{{- printf .template .user -}}"><i class="{{- .icon.class -}}"></i>{{ .title }}</a></li>
+                <li><a href="{{- printf .template .user -}}" rel="me"><i class="{{- .icon.class -}}"></i>{{ .title }}</a></li>
                 {{- else if .url -}}
                 <li><a href="{{- .url -}}"><i class="{{- .icon.class -}}"></i>{{ .title }}</a></li>
                 {{- end -}}


### PR DESCRIPTION
The rel parameter of the HTML <a> tag for social links is now set to "me". This is an indication that the linked page is another representation of the owner of the website. It can be by e.g. Mastodon to verify that the website belongs to a user.

Closes #14 
