### PR TITLE
Add CI job building the example page

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -1,0 +1,36 @@
+---
+name: Check
+
+on:
+  pull_request:
+    branches: ["master"]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      HUGO_VERSION: 0.102.3
+    steps:
+      - name: Install Hugo CLI
+        run: |
+          wget -O ${{ runner.temp }}/hugo.deb https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_Linux-64bit.deb \
+          && sudo dpkg -i ${{ runner.temp }}/hugo.deb
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
+      - name: Build with Hugo
+        env:
+          HUGO_ENVIRONMENT: production
+          HUGO_ENV: production
+        run: |
+          set -x
+          pwd
+          ls
+          hugo \
+            --minify \
+            --baseURL grotius.example.com \
+            --theme hugo-theme-notrack/ \
+            --themesDir ../../ \
+            --printUnusedTemplates \
+        working-directory: ./exampleSite


### PR DESCRIPTION
This PR creates a "check" CI pipeline that run on all changes to a PR and makes sure it's still possible to build the example website with the new changes.

Closes #16 