### PR TITLE
MathJax and button to switch between languages on multilingual sites

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -16,4 +16,7 @@
     {{ range .AlternativeOutputFormats -}}
         {{ printf `<link rel="%s" type="%s" href="%s" title="%s" />` .Rel .MediaType.Type .Permalink $.Site.Title | safeHTML }}
     {{ end -}}
+    {{ if eq .Params.math true }}
+        {{ partial "mathjax-support.html" . }}
+    {{ end }}
 </head>

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -5,6 +5,24 @@
     </div>
     <nav>
         <ul class="navbar">
+
+        {{- /* language switching button(s) */ -}}
+        {{ if .Site.IsMultiLingual }}
+            {{ if .IsTranslated }}
+                {{ range .Translations }}
+                    <li class="lang">
+                        <a href="{{ .RelPermalink }}">{{ .Language.Params.code }}</a>
+                    </li>
+                {{ end -}}
+            {{ else -}}
+                {{ range .Site.Languages }}
+                    <li class="lang">
+                        <a href="{{ .Lang | relURL }}">{{ .Params.code }}</a>
+                    </li>
+                {{ end -}}
+            {{ end -}}
+        {{ end -}}
+
         {{- /* info about current page */ -}}
             {{- $currentPage := . -}}
             {{- $currentPagesParent := $currentPage.Parent -}}

--- a/layouts/partials/mathjax-support.html
+++ b/layouts/partials/mathjax-support.html
@@ -1,0 +1,31 @@
+<!-- Taken from https://carmelgafa.com/post/hugo_mathjax/ -->
+
+<script type="text/javascript" async
+src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS-MML_HTMLorMML">
+    MathJax.Hub.Config({
+    tex2jax: {
+      inlineMath: [['$','$'], ['\\(','\\)']],
+      displayMath: [['$$','$$']],
+      processEscapes: true,
+      processEnvironments: true,
+      skipTags: ['script', 'noscript', 'style', 'textarea', 'pre'],
+      TeX: { equationNumbers: { autoNumber: "AMS" },
+           extensions: ["AMSmath.js", "AMSsymbols.js"] }
+    }
+    });
+
+    MathJax.Hub.Queue(function() {
+      // Fix <code> tags after MathJax finishes running. This is a
+      // hack to overcome a shortcoming of Markdown. Discussion at
+      // https://github.com/mojombo/jekyll/issues/199
+      var all = MathJax.Hub.getAllJax(), i;
+      for(i = 0; i < all.length; i += 1) {
+          all[i].SourceElement().parentNode.className += ' has-jax';
+      }
+    });
+
+    MathJax.Hub.Config({
+    // Autonumbering by mathjax
+    TeX: { equationNumbers: { autoNumber: "AMS" } }
+    });
+</script>

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -260,6 +260,13 @@ nav li:hover {
   border-color: #ddd;
 }
 
+.lang {
+  background-color: #f9f9f9;
+  color: #444;
+  cursor: pointer;
+  font-size: 0.6em;
+}
+
 .dropdown .sub-menu {
   display: none;
   position: absolute;
@@ -273,7 +280,7 @@ nav li:hover {
   z-index: 1;
 }
 
-.dropdown:hover .sub-menu {
+.dropdown:hover .lang:hover .sub-menu {
   display: block;
 }
 


### PR DESCRIPTION
For my Hugo site I wanted MathJax support so I made a fork a while back to add it. I think it would be a useful addition to the original version of the theme as well. Even better would be if someone codes in other web LaTeX alternatives to MathJax and adds them together; I couldn't get KaTeX to work for example.

Also, I recently decided to make my website both English and French, and so I needed a button in the main navbar to switch between languages. Could my suggestion be reviewed and maybe improved upon to add to the main repo?

By the way: great theme!