### PR TITLE
Fix incompatibility with Hugo 0.112.1 in shortcode

### DIFF
--- a/layouts/shortcodes/contact-box.html
+++ b/layouts/shortcodes/contact-box.html
@@ -1,8 +1,8 @@
 {{ with $.Page.Site.Params.social }}
 {{ $socialMap := $.Page.Site.Data.notrack.social }}
-{{ $width := default "12em" (.Get "width") }}
-{{ $height := default "auto" (.Get "height") }}
-{{ $float := default "right" (.Get "float") }}
+{{ $width := default "12em" (.Params.Get "width") }}
+{{ $height := default "auto" (.Params.Get "height") }}
+{{ $float := default "right" (.Params.Get "float") }}
 <div class="contactbox {{ $float }}" style="width: {{ $width }}; height: {{ $height }}">
     <ul>
     {{- $socialArray := slice -}}


### PR DESCRIPTION
A bug was discovered with Hugo 0.112.1 where shortcode parameters were seemingly incorrectly references, making the example site fail to build. This bug has been fixed now by referencing the shortcode parameters correctly.

Closes #24 