### PR TITLE
replace use of absolute URLs with relative URLs

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -25,7 +25,7 @@
 
             {{ range $taxonomyName, $taxonomy := .Site.Taxonomies }}
                 {{ if or (in $taxonomyName "categ") (in $taxonomyName "tag") }}
-            <li><a href="{{ $taxonomyName | absURL }}">{{ $taxonomyName }}</a></li>
+            <li><a href="{{ $taxonomyName | relURL }}">{{ $taxonomyName }}</a></li>
                 {{ end }}
             {{ end }}
         </ul>

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -1,14 +1,14 @@
 
 <head>
     <title>{{ .Site.Title }} {{ with .Title }}- {{ . }} {{ end }}</title>
-    <link rel="stylesheet" type="text/css" href="{{ "css/fonts.css" | absURL }}">
-    <link rel="stylesheet" type="text/css" href="{{ "css/fontawesome.css" | absURL }}">
-    <link rel="stylesheet" type="text/css" href="{{ "css/styles.css" | absURL }}">
+    <link rel="stylesheet" type="text/css" href="{{ "css/fonts.css" | relURL }}">
+    <link rel="stylesheet" type="text/css" href="{{ "css/fontawesome.css" | relURL }}">
+    <link rel="stylesheet" type="text/css" href="{{ "css/styles.css" | relURL }}">
     {{ with resources.Get "css/userstyles.css" }}
     <link rel="stylesheet" type="text/css" href="{{ .Permalink }}">
     {{ end }}
     {{ with .Site.Params.favicon }}
-    <link rel="icon" href="{{ . | absURL }}">
+    <link rel="icon" href="{{ . | relURL }}">
     {{ end }}
     <meta charset="UTF-8">
     <meta name="author" content="{{ .Site.Params.Author }}">

--- a/layouts/shortcodes/gallery-photo.html
+++ b/layouts/shortcodes/gallery-photo.html
@@ -1,4 +1,4 @@
 <li class="gallery-photo">
-    <img src="{{ ( printf "img/thumbnails/%s" (.Get "fn")) | absURL }}" }}
+    <img src="{{ ( printf "img/thumbnails/%s" (.Get "fn")) | relURL }}" }}
          alt="{{ .Get "caption" }}">
 </li>

--- a/layouts/shortcodes/image.html
+++ b/layouts/shortcodes/image.html
@@ -8,7 +8,7 @@
     {{- if .Get "link" -}}
         <a href="{{ .Get "link" }}"{{ with .Get "target" }} target="{{ . }}"{{ end }}{{ with .Get "rel" }} rel="{{ . }}"{{ end }}>
     {{- end }}
-    <img src="{{ .Get "src" | absURL }}"
+    <img src="{{ .Get "src" | relURL }}"
          {{- if or (.Get "alt") (.Get "caption") }}
          alt="{{ with .Get "alt" }}{{ . }}{{ else }}{{ .Get "caption" | markdownify| plainify }}{{ end }}"
          {{- end -}}


### PR DESCRIPTION
Referencing assets by relative URL makes it a little easier for me to support accessing the website through multiple URLs (ie: https://domain.com and https://www.domain.com).