### PR TITLE
Fix broken category and tag links

### DIFF
--- a/layouts/partials/blog-taxonomy-info.html
+++ b/layouts/partials/blog-taxonomy-info.html
@@ -3,7 +3,7 @@
         {{ $sort := sort . }}
         {{ $links := apply $sort "partial" "post-category-link" "." }}
         {{ $clean := apply $links "chomp" "." }}
-        {{ delimit $clean ", " }}
+        {{ delimit $clean ", " | safeHTML }}
     </span>
 {{ end }}
 
@@ -12,6 +12,6 @@
         {{ $sort := sort . }}
         {{ $links := apply $sort "partial" "post-tag-link" "." }}
         {{ $clean := apply $links "chomp" "." }}
-        {{ delimit $clean ", " }}
+        {{ delimit $clean ", " | safeHTML }}
     </span>
 {{ end }}


### PR DESCRIPTION
Since Hugo 0.120.0 the output of `delimit` is now deHTMLized. For example, it turns '<a>' into '&lt;a&gt;' in the final output. `delimit` is used to create lists of categories and tags in the blog posts summary, so it affects these lists, breaking HTML links in them.

We can bring it back to working HTML by piping it to the `safeHTML` function. This commit does that.

Resolves #30 