### PR TITLE
fix long codeblocks overflowing the div blog-post-content

### DIFF
--- a/assets/styles.scss
+++ b/assets/styles.scss
@@ -152,6 +152,7 @@ pre {
     padding: 0.5em;
     code {
         background-color: transparent;
+        white-space: preserve;
     }
 }
 

--- a/assets/styles.scss
+++ b/assets/styles.scss
@@ -150,9 +150,10 @@ kbd, code {
 pre {
     background-color: $codeblock-background;
     padding: 0.5em;
+    overflow: auto;
+    
     code {
         background-color: transparent;
-        white-space: preserve;
     }
 }
 


### PR DESCRIPTION
Long lines of code within code blocks overflow the `blog-post-content` div, creating horizontal scroll bars. It does not occur with standard p, ul, etc.

Tested using Hugo 0.145.0, Firefox, and Chromium.