### PR TITLE
Fix visual diff bug and extend to full page

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -112,8 +112,8 @@ jobs:
 
           subpages=("resume" "blog" "hugo-gallery" "contact" "categories")
           for page in "${subpages[@]}"; do
-            npx playwright screenshot http://localhost:8080/resume master-${page}.png
-            npx playwright screenshot http://localhost:8081/resume pr-${page}.png
+            npx playwright screenshot --full-page http://localhost:8080/${page} master-${page}.png
+            npx playwright screenshot --full-page http://localhost:8081/${page} pr-${page}.png
           done
       - name: Compare screenshots
         id: diff


### PR DESCRIPTION
Fix a bug in the visual diff workflow where it didn't loop through all
configured pages. And also make the screenshots fullpage so that no
parts are missed.
